### PR TITLE
Don't rely on globally installed packages to run tests or build assets.

### DIFF
--- a/packages/schema-dot-org-json-ld-components/package.json
+++ b/packages/schema-dot-org-json-ld-components/package.json
@@ -21,6 +21,7 @@
   "repository": "https://github.com/zillow/schema-dot-org-markup",
   "license": "ISC",
   "devDependencies": {
+    "babel-cli": "^6.26.0",
     "babel-register": "^6.26.0",
     "flow-copy-source": "^1.2.0",
     "mocha": "^4.0.1",
@@ -31,5 +32,8 @@
   },
   "peerDependencies": {
     "react": "^15.6.2 || ^16.0.0"
+  },
+  "engines": {
+    "npm": ">=5.2"
   }
 }

--- a/packages/schema-dot-org-types/package.json
+++ b/packages/schema-dot-org-types/package.json
@@ -24,6 +24,7 @@
   "license": "ISC",
   "devDependencies": {
     "JSONStream": "^1.3.1",
+    "babel-cli": "^6.26.0",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-register": "^6.26.0",
     "commander": "^2.9.0",
@@ -32,6 +33,8 @@
     "find-up": "latest",
     "flow-copy-source": "^1.1.0",
     "load-json-file": "latest",
+    "mocha": "^4.0.1",
+    "rollup": "^0.66.0",
     "request": "^2.81.0",
     "schema.org": "^3.1.0",
     "url-template": "^2.0.8"
@@ -39,5 +42,8 @@
   "dependencies": {
     "moment": "^2.18.1",
     "object-assign": "^4.1.1"
+  },
+  "engines": {
+    "npm": ">=5.2"
   }
 }


### PR DESCRIPTION
I was a bit peeved when it failed to install when I forked it.

Just install `babel`, `rollup` and `mocha` locally and let `npm` figure things out.